### PR TITLE
[SDK-917] fix: set config before load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,15 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.3.2] - 2024.04.25
+
+### Fixed
+- Issue causing avatar config settings not wt be applied [#11](https://github.com/readyplayerme/rpm-unity-sdk-photon-support/pull/11)
+
 ## [0.3.1] - 2024.03.01
 
 ### Updated
-- Added all possible mesh options to Photon Test Character for multi-mesh avatar support. [#241](https://github.com/readyplayerme/rpm-unity-sdk-photon-support/pull/7)
+- Added all possible mesh options to Photon Test Character for multi-mesh avatar support. [#7](https://github.com/readyplayerme/rpm-unity-sdk-photon-support/pull/7)
 
 ## [0.3.0] - 2024.01.17
 

--- a/Runtime/NetworkPlayer.cs
+++ b/Runtime/NetworkPlayer.cs
@@ -40,13 +40,12 @@ namespace ReadyPlayerMe.PhotonSupport
         private void SetPlayer(string incomingUrl)
         {
             AvatarObjectLoader loader = new AvatarObjectLoader();
-            loader.LoadAvatar(incomingUrl);
             loader.AvatarConfig = config;
+            loader.LoadAvatar(incomingUrl);
             loader.OnCompleted += (sender, args) =>
             {
                 leftEye.transform.localPosition = AvatarBoneHelper.GetLeftEyeBone(args.Avatar.transform, true).localPosition;
                 rightEye.transform.localPosition = AvatarBoneHelper.GetRightEyeBone(args.Avatar.transform, true).localPosition;
-
                 AvatarMeshHelper.TransferMesh(args.Avatar, gameObject);
                 Destroy(args.Avatar);
             };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.readyplayerme.photonsupport",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "displayName": "Ready Player Me Photon Support",
   "description": "NetworkPlayer component that allows to use Ready Player Me avatars in Photon Unity Networking 2.",
   "unity": "2020.3",


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Jira and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [SDK-917](https://ready-player-me.atlassian.net/browse/SDK-917)

## Description

-   small fix to ensure avatar config is set before loading avatar

<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

<!-- Testability -->

## How to Test

-  run dmeo scene, check that avatar is loading with appropriate settings applied from the config assigned on the NetworkPlayer component on the photon prefab

![image](https://github.com/readyplayerme/rpm-unity-sdk-photon-support/assets/7085672/e3104b6e-4962-4d79-9e7e-ba96e03d28b4)


<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->





[SDK-917]: https://ready-player-me.atlassian.net/browse/SDK-917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ